### PR TITLE
Issue #6:  Server side support for getting/updating DoseEvents

### DIFF
--- a/server/src/main/java/info/doseamigos/doseevents/DoseEventDao.java
+++ b/server/src/main/java/info/doseamigos/doseevents/DoseEventDao.java
@@ -1,11 +1,11 @@
 package info.doseamigos.doseevents;
 
-import info.doseamigos.amigousers.AmigoUser;
-import info.doseamigos.meds.Med;
-
 import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
+
+import info.doseamigos.amigousers.AmigoUser;
+import info.doseamigos.meds.Med;
 
 /**
  * Dao for creating, getting, and updating DoseEvents.
@@ -39,4 +39,11 @@ public interface DoseEventDao {
      * @param doseEvents The events to update.
      */
     void updateDoseEvents(List<DoseEvent> doseEvents) throws SQLException;
+
+    List<DoseEvent> getEventsForUser(AmigoUser amigoUser, Date startDate, String dir);
+
+    /**
+     * Single transaction that marks all events as missed if they're overdue by an hour.
+     */
+    void markMissedEvents() throws SQLException;
 }

--- a/server/src/main/java/info/doseamigos/doseevents/DoseEventService.java
+++ b/server/src/main/java/info/doseamigos/doseevents/DoseEventService.java
@@ -1,11 +1,12 @@
 package info.doseamigos.doseevents;
 
-import info.doseamigos.amigousers.AmigoUser;
-import info.doseamigos.authusers.AuthUser;
-import info.doseamigos.meds.Med;
-
 import java.util.Date;
 import java.util.List;
+
+import info.doseamigos.amigousers.AmigoUser;
+import info.doseamigos.authusers.AuthUser;
+import info.doseamigos.doseseries.DoseSeries;
+import info.doseamigos.meds.Med;
 
 /**
  * Service that gets events for a specific user.
@@ -36,6 +37,19 @@ public interface DoseEventService {
     void generateDoseEventsForAllUsers();
 
     /**
+     * Generates a bunch of new events for a Dose Series.  Meant to be called when adding a new Dose Series for the
+     * first time.
+     * @param series Series to generate events for
+     * @return The newly generated events.
+     */
+    List<DoseEvent> generateWeekEventsForSeries(DoseSeries series);
+
+    /**
+     * Cron job method that should mark all events that took place over an hour ago as Missed
+     */
+    void markMissedEvents();
+
+    /**
      * Gets a list of events for the user that end at the end of the day.  This will include all events before today
      * with no action associated with it.
      * @param authUser The AuthUser making the request, for validation purposes.
@@ -51,4 +65,15 @@ public interface DoseEventService {
      * @return The updated list of DoseEvents.
      */
     List<DoseEvent> updateDoseEvents(AuthUser authUser, List<DoseEvent> doseEvents);
+
+    /**
+     * Get DoseEvents to display for the phone.
+     * @param authUser The auth user making the call
+     * @param startDate The start date
+     * @param dir Whether we want the first dose after date, or last dose before date.
+     * @return The list of doses at the same time.
+     */
+    List<DoseEvent> getDosesForPhone(AuthUser authUser, Date startDate, String dir);
+
+
 }

--- a/server/src/main/java/info/doseamigos/doseevents/DoseEventWebService.java
+++ b/server/src/main/java/info/doseamigos/doseevents/DoseEventWebService.java
@@ -1,5 +1,11 @@
 package info.doseamigos.doseevents;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.List;
+
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.LambdaLogger;
 import com.amazonaws.util.IOUtils;
@@ -9,14 +15,8 @@ import com.google.inject.Injector;
 import info.doseamigos.ClientRequestObject;
 import info.doseamigos.CommonModule;
 import info.doseamigos.amigousers.AmigoUserGuiceModule;
-import info.doseamigos.authusers.AuthUser;
 import info.doseamigos.doseseries.DoseSeriesGuiceModule;
 import info.doseamigos.meds.MedGuiceModule;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.List;
 
 /**
  * WebService for DoseEvents.
@@ -36,6 +36,53 @@ public class DoseEventWebService {
         );
         service = injector.getInstance(DoseEventService.class);
         objectMapper = injector.getInstance(ObjectMapper.class);
+    }
+
+    public void getDoseEvents(
+            InputStream inputStream,
+            OutputStream outputStream,
+            Context context
+    ) throws IOException {
+        LambdaLogger logger = context.getLogger();
+
+        //Logging purposes
+        String streamContents = IOUtils.toString(inputStream);
+        logger.log("Stream Contents: " + streamContents);
+
+        ClientRequestObject<Object> clientRequestObject = objectMapper.readValue(
+                streamContents,
+                objectMapper.getTypeFactory().constructParametrizedType(
+                        ClientRequestObject.class,
+                        ClientRequestObject.class,
+                        Object.class
+                )
+        );
+
+        logger.log("Calling updateDoseEvents");
+        logger.log("Input: " + clientRequestObject.getQueryParams());
+        logger.log("User: " + clientRequestObject.getSessionUser());
+
+        String startAtStr = clientRequestObject.getQueryParams().get("startAt");
+        Date startAt = null;
+        if (startAtStr == null) {
+            startAt = new Date();
+        } else {
+            startAt = new Date(Long.parseLong(startAtStr));
+
+        }
+
+        String dir = clientRequestObject.getQueryParams().get("dir");
+        if (dir == null) {
+            dir = "next";
+        }
+
+        List<DoseEvent> events = service.getDosesForPhone(
+                clientRequestObject.getSessionUser(),
+                startAt,
+                dir
+        );
+
+        objectMapper.writeValue(outputStream, events);
     }
 
     /**
@@ -76,5 +123,31 @@ public class DoseEventWebService {
             service.updateDoseEvents(clientRequestObject.getSessionUser(), clientRequestObject.getBody());
 
         objectMapper.writeValue(outputStream, updatedEvents);
+    }
+
+    /**
+     * Cron job for marking missed doses, should run every 15 minutes or so.
+     * @param inputStream
+     * @param outputStream
+     * @param context
+     * @throws IOException
+     */
+    public void autoMarkMissed(
+        InputStream inputStream,
+        OutputStream outputStream,
+        Context context
+    ) throws IOException {
+        service.markMissedEvents();
+    }
+
+    /**
+     * Cron job for generating dose events from a series, should run once a week at the same time every week.
+     */
+    public void generateEvents(
+        InputStream inputStream,
+        OutputStream outputStream,
+        Context context
+    ) throws IOException {
+        service.generateDoseEventsForAllUsers();
     }
 }


### PR DESCRIPTION
Added a way to grab Dose events based on the startAt date and whether
you're going forward or backwards in time to find the dose events to
get.  Also added in lambda methods that handle generating dose events
on existing dose series and auto-marking dose events as missed.
